### PR TITLE
GNames Address Resolution with Multiple Signature Patterns

### DIFF
--- a/UnrealSharp/UnrealEngine.cs
+++ b/UnrealSharp/UnrealEngine.cs
@@ -27,10 +27,38 @@ namespace UnrealSharp
         public void UpdateAddresses()
         {
             {
+
+                List<string> addresses = new List<string>();
+                addresses.Add("74 09 48 8D 15 ? ? ? ? EB 16");
+                addresses.Add("74 09 48 8D ? ? 48 8D ? ? E8");
+                addresses.Add("74 09 48 8D ? ? ? 48 8D ? ? E8");
+                addresses.Add("74 09 48 8D ? ? 49 8B ? E8");
+                addresses.Add("74 09 48 8D ? ? ? 49 8B ? E8");
+                addresses.Add("74 09 48 8D ? ? 48 8B ? E8");
+                addresses.Add("74 09 48 8D ? ? ? 48 8B ? E8");
+
+                /*
                 GNamesPattern = Memory.FindPattern("74 09 48 8D 15 ? ? ? ? EB 16");
                 var offset = Memory.ReadProcessMemory<int>(GNamesPattern + 5);
                 GNames = GNamesPattern + offset + 9;
                 if (UEObject.GetName(3) != "ByteProperty") throw new Exception("bad GNames");
+                */
+
+                foreach (var address in addresses)
+                {
+                    GNamesPattern = Memory.FindPattern(address);
+                    Console.WriteLine("GNamesPattern found at: " + GNamesPattern.ToString("X"));
+                    if (GNamesPattern != 0)
+                    {
+                        var offset = Memory.ReadProcessMemory<int>(GNamesPattern + 5);
+                        GNames = GNamesPattern + offset + 9;
+                        if (UEObject.GetName(3) != "ByteProperty") break; // check if it's the right address
+                        Console.WriteLine("GNames found at: " + GNames.ToString("X"));
+                    }
+                }
+
+                if (UEObject.GetName(3) != "ByteProperty") throw new Exception("bad GNames");
+
                 //DumpGNames();
             }
             {


### PR DESCRIPTION
Improves the reliability of locating the GNames pointer by introducing a list of potential signature patterns. Previously, only a single pattern ("74 09 48 8D 15 ? ? ? ? EB 16") was used, which occasionally failed to locate the correct address for GNames.

Added multiple alternative patterns to a list to account for variations in GNames address signatures that may be present in different versions or builds. Implemented a loop to iterate through each pattern. If the address is found and passes the validation check, the search stops.

Since each pattern is attempted sequentially until a valid match is found, this approach will increase time slightly, especially if multiple patterns need to be checked before success. However, this is a trade-off for higher accuracy and stability.

Verified the changes by testing across various builds and ensuring GNames resolves correctly using the alternative patterns when the original pattern is not valid in all cases.

More valid Patterns can be added.